### PR TITLE
Added a facility to use SAS Tokens with the  redirect path option.

### DIFF
--- a/build/content/ImageProcessor.Web.Plugins.AzureBlobCache/config/imageprocessor/cache.config.transform
+++ b/build/content/ImageProcessor.Web.Plugins.AzureBlobCache/config/imageprocessor/cache.config.transform
@@ -10,6 +10,7 @@
         <setting key="SourceStorageAccount" value=""/>
         <setting key="SourceBlobContainer" value=""/>
         <setting key="StreamCachedImage" value="false"/>
+        <setting key="UseSASTokens" value="true" />
       </settings>
     </cache>
   </caches>

--- a/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
+++ b/src/ImageProcessor.Web.Plugins.AzureBlobCache/AzureBlobCache.cs
@@ -72,7 +72,22 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
         /// <summary>
         /// Determines if the CDN redirect uses an SAS token. ( Requires streamCachedImage to be true. ) 
         /// </summary>
-        private readonly bool useSASTokens;
+        private readonly bool useSASToken;
+
+        /// <summary>
+        /// The duration for sas tokens to be valid for
+        /// </summary>
+        private readonly int sasTokenExpiryMinutes = 30;
+
+        /// <summary>
+        /// The currently derived shared access policy
+        /// </summary>
+        private static SharedAccessBlobPolicy currentSasPolicy = null;
+
+        /// <summary>
+        /// The sas token if in use
+        /// </summary>
+        private readonly string sasToken = "";
 
         /// <summary>
         /// The timeout length for requesting the CDN url.
@@ -147,8 +162,44 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             this.streamCachedImage = this.Settings.ContainsKey("StreamCachedImage") && this.Settings["StreamCachedImage"].ToLower() == "true";
             if ( !this.streamCachedImage )
             {
-                // SAS tokens allow temporary access to otherwise private resources.
-                this.useSASTokens = this.Settings.ContainsKey("UseSASTokens") && this.Settings["UseSASTokens"].Equals("true", StringComparison.InvariantCultureIgnoreCase);
+                // SAS tokens allow temporary access to otherwise private resources. If set to true we will use this for the media cache container
+                this.useSASToken = this.Settings.ContainsKey("UseSASToken") && this.Settings["UseSASToken"].Equals("true", StringComparison.InvariantCultureIgnoreCase);
+                if (this.useSASToken)
+                {
+                    if (this.Settings.ContainsKey("SASTokenExpiryMinutes"))
+                    {
+                        int sasTokenExpiryMinutesCfg;
+                        if (int.TryParse(this.Settings["SASTokenExpiryMinutes"], out sasTokenExpiryMinutesCfg))
+                        {
+                            this.sasTokenExpiryMinutes = sasTokenExpiryMinutesCfg;
+                        }
+                    }
+                    // Generate a new token if the previous one is going to run out in less than the expiry time / 2
+                    if (currentSasPolicy == null || (currentSasPolicy.SharedAccessExpiryTime ?? DateTime.UtcNow) > DateTime.UtcNow.AddMinutes(0 - sasTokenExpiryMinutes / 2))
+                    {
+                        currentSasPolicy = new SharedAccessBlobPolicy();
+                        currentSasPolicy.SharedAccessExpiryTime = DateTime.UtcNow.AddMinutes(sasTokenExpiryMinutes);
+                        currentSasPolicy.Permissions = SharedAccessBlobPermissions.Read;
+                    }
+                }
+            }
+        }
+
+        private static string AppendSasToken(string url)
+        {
+            if(currentSasPolicy == null)
+            {
+                return url;
+            }
+
+            var token = cloudCachedBlobContainer.GetSharedAccessSignature(currentSasPolicy);
+            // token starts with a ? - so deal with it
+            if (url.IndexOf("?") == -1)
+            {
+                return url + token;
+            } else
+            {
+                return url += "&" + token.Substring(1);
             }
         }
 
@@ -164,8 +215,9 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
             // if the last time it was checked is greater than 5 seconds. This would be much better for perf
             // if there is a high throughput of image requests.
             string cachedFileName = await this.CreateCachedFileNameAsync();
-            this.CachedPath = CachedImageHelper.GetCachedPath(cloudCachedBlobContainer.Uri.ToString(), cachedFileName, true, this.FolderDepth);
 
+            this.CachedPath = CachedImageHelper.GetCachedPath(cloudCachedBlobContainer.Uri.ToString(), cachedFileName, true, this.FolderDepth);
+            
             // Do we insert the cache container? This seems to break some setups.
             bool useCachedContainerInUrl = this.Settings.ContainsKey("UseCachedContainerInUrl") && this.Settings["UseCachedContainerInUrl"].ToLower() != "false";
 
@@ -201,13 +253,6 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
 
                     if (blockBlob.Properties.LastModified.HasValue)
                     {
-                        if ( useSASTokens)
-                        {
-                            SharedAccessBlobPolicy policy = new SharedAccessBlobPolicy();
-                            policy.SharedAccessExpiryTime = DateTime.UtcNow.AddMinutes(1);
-                            policy.Permissions = SharedAccessBlobPermissions.Read;
-                            this.CachedPath += blockBlob.GetSharedAccessSignature(policy);
-                        }
                         cachedImage = new CachedImage
                         {
                             Key = Path.GetFileNameWithoutExtension(this.CachedPath),
@@ -479,7 +524,12 @@ namespace ImageProcessor.Web.Plugins.AzureBlobCache
                     response = (HttpWebResponse)request.GetResponse();
                     response.Dispose();
                     ImageProcessingModule.AddCorsRequestHeaders(context);
-                    context.Response.Redirect(this.cachedRewritePath, false);
+                    var path = this.cachedRewritePath;
+                    if(useSASToken)
+                    {
+                        path = AppendSasToken(this.cachedRewritePath);
+                    }
+                    context.Response.Redirect(path, false);
                 }
                 catch (WebException ex)
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageProcessor/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds an SASToken configuration element and adds the value to the cached url if it is enabled.

<!-- Thanks for contributing to ImageProcessor! -->
